### PR TITLE
Allow running commands on macOS

### DIFF
--- a/lib/osacompile.js
+++ b/lib/osacompile.js
@@ -7,7 +7,7 @@ const vscode = require('vscode');
 
 function osacompileCommand (textEditor, compileTarget) {
 
-  if (os.platform() === 'darwin') {
+  if (os.platform() !== 'darwin') {
     return vscode.window.showWarningMessage("This command is only available on macOS");
   }
 

--- a/lib/osascript.js
+++ b/lib/osascript.js
@@ -6,7 +6,7 @@ const vscode = require('vscode');
 
 function osascriptCommand (textEditor) {
 
-  if (os.platform() === 'darwin') {
+  if (os.platform() !== 'darwin') {
     return vscode.window.showWarningMessage("This command is only available on macOS");
   }
 


### PR DESCRIPTION
Just a quick fix. I understand the initial intention was to prevent running commands on Windows and Linux, not the opposite. 😄 